### PR TITLE
Fix Sniper zoom orientation

### DIFF
--- a/blackshades/Source/GameTick.cpp
+++ b/blackshades/Source/GameTick.cpp
@@ -851,7 +851,7 @@ void 	Game::Tick(){
 
 		
 
-		if(zoom||person[0].aimamount<=0||person[0].whichgun==nogun||visions||person[0].whichgun==grenade||person[0].whichgun==knife){
+		if(oldzoom||zoom||person[0].aimamount<=0||person[0].whichgun==nogun||visions||person[0].whichgun==grenade||person[0].whichgun==knife){
 
 			camera.visrotation=camera.rotation;
 

--- a/blackshades/Source/GameTick.cpp
+++ b/blackshades/Source/GameTick.cpp
@@ -1713,7 +1713,12 @@ void 	Game::Tick(){
 
 							zoom=1;
 
-							if(zoom&&!oldzoom)camera.rotation2-=6;
+							if(zoom&&!oldzoom){
+
+								camera.rotation2-=14;
+								camera.rotation-=9;
+
+							}
 
 						}
 

--- a/blackshades/Source/GameTick.cpp
+++ b/blackshades/Source/GameTick.cpp
@@ -1699,7 +1699,7 @@ void 	Game::Tick(){
 
 							mousesensitivity=.05*usermousesensitivity;
 
-							if(person[i].targetanimation!=crouchanim||person[i].currentanimation!=crouchanim||person[i].aiming<1){
+							if(person[i].targetanimation!=crouchanim||person[i].currentanimation!=crouchanim||person[i].aiming<1||visions==1){
 
 								zoom=0;
 								camera.rotation2+=14;
@@ -1707,15 +1707,13 @@ void 	Game::Tick(){
 
 							}
 
-							if(visions==1)zoom=0;
-
 						}
 
 						if(person[i].currentanimation==crouchanim&&person[i].targetanimation==crouchanim&&person[i].aiming>=1&&person[i].whichgun==sniperrifle){
 
 							zoom=1;
 
-							if(zoom&&!oldzoom){
+							if(!oldzoom){
 
 								camera.rotation2-=14;
 								camera.rotation-=9;

--- a/blackshades/Source/GameTick.cpp
+++ b/blackshades/Source/GameTick.cpp
@@ -1702,6 +1702,8 @@ void 	Game::Tick(){
 							if(person[i].targetanimation!=crouchanim||person[i].currentanimation!=crouchanim||person[i].aiming<1){
 
 								zoom=0;
+								camera.rotation2+=14;
+								camera.rotation+=9;
 
 							}
 


### PR DESCRIPTION
This makes zooming with the sniper nicer by rotating the camera less (actually more, but the visible rotation is lessened greatly) and undoing the rotation when zooming out.